### PR TITLE
fix: escaping special characters when passing env to ssh

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -73,7 +73,7 @@ func (p Plugin) exec(host string, wg *sync.WaitGroup, errChannel chan error) {
 		key = strings.ToUpper(key)
 		val := os.Getenv(key)
 		val = strings.Replace(val, " ", "", -1)
-		env = append(env, key+"="+val)
+		env = append(env, key+"='"+val+"'")
 	}
 
 	p.Config.Script = append(env, p.Config.Script...)

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -232,7 +232,7 @@ func TestSSHCommandExitCodeError(t *testing.T) {
 }
 
 func TestSetENV(t *testing.T) {
-	os.Setenv("FOO", "1")
+	os.Setenv("FOO", "1)")
 	plugin := Plugin{
 		Config: Config{
 			Host:           []string{"localhost"},


### PR DESCRIPTION
Published to dockerhub as `rushpl/drone-ssh`