### PR TITLE
improve: shell escaping, allow for whitespace and single quotes

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -43,6 +43,10 @@ type (
 	}
 )
 
+func escapeArg(arg string) string {
+	return "'" + strings.Replace(arg, "'", `'\''`, -1) + "'"
+}
+
 func (p Plugin) exec(host string, wg *sync.WaitGroup, errChannel chan error) {
 	// Create MakeConfig instance with remote username, server address and path to private key.
 	ssh := &easyssh.MakeConfig{
@@ -72,8 +76,7 @@ func (p Plugin) exec(host string, wg *sync.WaitGroup, errChannel chan error) {
 	for _, key := range p.Config.Envs {
 		key = strings.ToUpper(key)
 		val := os.Getenv(key)
-		val = strings.Replace(val, " ", "", -1)
-		env = append(env, key+"='"+val+"'")
+		env = append(env, key+"="+escapeArg(val))
 	}
 
 	p.Config.Script = append(env, p.Config.Script...)

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -232,7 +232,7 @@ func TestSSHCommandExitCodeError(t *testing.T) {
 }
 
 func TestSetENV(t *testing.T) {
-	os.Setenv("FOO", "1)")
+	os.Setenv("FOO", `'  1)  '`)
 	plugin := Plugin{
 		Config: Config{
 			Host:           []string{"localhost"},


### PR DESCRIPTION
Sorry, I was multi-tasking when doing my previous PR. :-) I had a second look at the problem and noticed that it doesn't handle single quotes. Also, you had some code that was removing white spaces. I believe this PR should allow for any input inside the env vars.