### PR TITLE
Add option to use file for host info

### DIFF
--- a/main.go
+++ b/main.go
@@ -60,9 +60,10 @@ func main() {
 			EnvVar: "PLUGIN_PASSWORD,SSH_PASSWORD,PASSWORD,INPUT_PASSWORD",
 		},
 		cli.StringSliceFlag{
-			Name:   "host,H",
-			Usage:  "connect to host",
-			EnvVar: "PLUGIN_HOST,SSH_HOST,HOST,INPUT_HOST",
+			Name:     "host,H",
+			Usage:    "connect to host",
+			EnvVar:   "PLUGIN_HOST,SSH_HOST,HOST,INPUT_HOST",
+			FilePath: ".host",
 		},
 		cli.IntFlag{
 			Name:   "port,p",


### PR DESCRIPTION
Add option to use file for host info. In my drone pipeline I create VMs that I don't know the IP before hand, so I need some way of passing host info to drone-ssh plugin.