### PR TITLE
fix(envs): 🐛 set environment variable instead of bash variable

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -103,7 +103,7 @@ func (p Plugin) exec(host string, wg *sync.WaitGroup, errChannel chan error) {
 	for _, key := range p.Config.Envs {
 		key = strings.ToUpper(key)
 		if val, found := os.LookupEnv(key); found {
-			env = append(env, key+"="+escapeArg(val))
+			env = append(env, "export "+key+"="+escapeArg(val))
 		}
 	}
 

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -539,13 +539,13 @@ func TestEnvOutput(t *testing.T) {
 			echo "[${ENV_7}]"
 			======END======
 			======ENV======
-			ENV_1='test'
-			ENV_2='test test'
-			ENV_3='test '
-			ENV_4='  test  test  '
-			ENV_5='test'\'''
-			ENV_6='test"'
-			ENV_7='test,!#;?.@$~'\''"'
+			export ENV_1='test'
+			export ENV_2='test test'
+			export ENV_3='test '
+			export ENV_4='  test  test  '
+			export ENV_5='test'\'''
+			export ENV_6='test"'
+			export ENV_7='test,!#;?.@$~'\''"'
 			======END======
 			out: [test]
 			out: [test test]


### PR DESCRIPTION
This PR changes would make environment variables accessible to any child processes that could be running via script, docker, or Makefile.

Signed-off-by: Prashant Shahi <me@prashantshahi.dev>