### PR TITLE
chore: flexible configuration of environment value transfer

### DIFF
--- a/main.go
+++ b/main.go
@@ -198,10 +198,10 @@ func main() {
 			EnvVars: []string{"PLUGIN_DEBUG", "DEBUG", "INPUT_DEBUG"},
 		},
 		&cli.StringFlag{
-			Name:    "shell",
-			Usage:   "shell on host",
-			EnvVars: []string{"PLUGIN_HOST_SHELL"},
-			Value:   "bash",
+			Name:    "envs.format",
+			Usage:   "",
+			EnvVars: []string{"PLUGIN_ENVS_FORMAT"},
+			Value:   "export {NAME}={VALUE}",
 		},
 	}
 
@@ -264,11 +264,11 @@ func run(c *cli.Context) error {
 			Script:            scripts,
 			ScriptStop:        c.Bool("script.stop"),
 			Envs:              c.StringSlice("envs"),
+			EnvsFormat:        c.String("envs.format"),
 			Debug:             c.Bool("debug"),
 			Sync:              c.Bool("sync"),
 			Ciphers:           c.StringSlice("ciphers"),
 			UseInsecureCipher: c.Bool("useInsecureCipher"),
-			Shell:             c.String("shell"),
 			Proxy: easyssh.DefaultConfig{
 				Key:               c.String("proxy.ssh-key"),
 				KeyPath:           c.String("proxy.key-path"),

--- a/main.go
+++ b/main.go
@@ -197,6 +197,12 @@ func main() {
 			Usage:   "debug mode",
 			EnvVars: []string{"PLUGIN_DEBUG", "DEBUG", "INPUT_DEBUG"},
 		},
+		&cli.StringFlag{
+			Name:    "shell",
+			Usage:   "shell on host",
+			EnvVars: []string{"PLUGIN_HOST_SHELL"},
+			Value:   "bash",
+		},
 	}
 
 	// Override a template
@@ -242,6 +248,7 @@ func run(c *cli.Context) error {
 	if s := c.String("script.string"); s != "" {
 		scripts = append(scripts, s)
 	}
+
 	plugin := Plugin{
 		Config: Config{
 			Key:               c.String("ssh-key"),
@@ -261,6 +268,7 @@ func run(c *cli.Context) error {
 			Sync:              c.Bool("sync"),
 			Ciphers:           c.StringSlice("ciphers"),
 			UseInsecureCipher: c.Bool("useInsecureCipher"),
+			Shell:             c.String("shell"),
 			Proxy: easyssh.DefaultConfig{
 				Key:               c.String("proxy.ssh-key"),
 				KeyPath:           c.String("proxy.key-path"),

--- a/plugin.go
+++ b/plugin.go
@@ -41,6 +41,7 @@ type (
 		Sync              bool
 		Ciphers           []string
 		UseInsecureCipher bool
+		Shell             string
 	}
 
 	// Plugin structure
@@ -99,11 +100,16 @@ func (p Plugin) exec(host string, wg *sync.WaitGroup, errChannel chan error) {
 	p.log(host, strings.Join(p.Config.Script, "\n"))
 	p.log(host, "======END======")
 
+	shell := p.Config.Shell
 	env := []string{}
 	for _, key := range p.Config.Envs {
 		key = strings.ToUpper(key)
 		if val, found := os.LookupEnv(key); found {
-			env = append(env, "export "+key+"="+escapeArg(val))
+			if shell == "bash" {
+				env = append(env, "export "+key+"="+escapeArg(val))
+			} else if shell == "powershell" {
+				env = append(env, "$env:"+key+" = "+escapeArg(val))
+			}
 		}
 	}
 

--- a/plugin.go
+++ b/plugin.go
@@ -104,7 +104,7 @@ func (p Plugin) exec(host string, wg *sync.WaitGroup, errChannel chan error) {
 	for _, key := range p.Config.Envs {
 		key = strings.ToUpper(key)
 		if val, found := os.LookupEnv(key); found {
-			env = append(env, p.format(p.Config.EnvsFormat, "NAME", key, "VALUE", val))
+			env = append(env, p.format(p.Config.EnvsFormat, "{NAME}", key, "{VALUE}", val))
 		}
 	}
 

--- a/plugin.go
+++ b/plugin.go
@@ -104,7 +104,7 @@ func (p Plugin) exec(host string, wg *sync.WaitGroup, errChannel chan error) {
 	for _, key := range p.Config.Envs {
 		key = strings.ToUpper(key)
 		if val, found := os.LookupEnv(key); found {
-			env = append(env, p.format(p.Config.EnvsFormat, "{NAME}", key, "{VALUE}", val))
+			env = append(env, p.format(p.Config.EnvsFormat, "{NAME}", key, "{VALUE}", escapeArg(val)))
 		}
 	}
 


### PR DESCRIPTION
Hi! I propose an example of implementing a more flexible setting for passing environment variables.

**Reason:**
I have to use drone-ssh to work with Windows SSH. Initially, drone-ssh is written so that it transmits environment variables through the `export` command. Which makes it unsuitable for working with Power Shell.

**Solution:**
I have added a new option to configure environment variable commands formatting, with default value: `export {NAME}={VALUE}`. When I use drone-ssh with PowerShell I set this option like this: `$env:{NAME} = {VALUE}`.

**Important!** I don't know Go, so my Pull Request is more of a Proof Of Concept and request of feature. I'm sure it can be done better.
