### PR TITLE
Add a no_auto_env setting

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -211,3 +211,4 @@ Example configuration for passphrase which protecting a private key:
 | `proxy_password` | password for proxy host user |
 | `proxy_key` | plain text of proxy private key |
 | `proxy_key_path` | key path of proxy private key |
+| `no_auto_env` | if true, will not automatically load configs from `.env` file |

--- a/README.md
+++ b/README.md
@@ -122,4 +122,6 @@ Configuration options are loaded from multiple sources:
 2. From a dotenv file at a path specified by the `PLUGIN_ENV_FILE` environment variable.
 3. From your `.drone.yml` Drone configuration.
 
+If a `PLUGIN_NO_AUTO_ENV` environment variable (or drone configuration setting `no_auto_env`) is `"true"`, the container will skip loading `.env` unless otherwise specified by the `PLUGIN_ENV_FILE` environment variable (or by the `env_file` drone configuration setting).
+
 Later sources override previous sources, i.e. if `PORT` is set in an `.env` file committed in the repository or created by previous test steps, it will override the default set `main.go`.

--- a/main.go
+++ b/main.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/appleboy/easyssh-proxy"
 	"github.com/joho/godotenv"
-	_ "github.com/joho/godotenv/autoload"
 	"github.com/urfave/cli/v2"
 )
 
@@ -15,6 +14,13 @@ import (
 var Version string
 
 func main() {
+	// Load dotenv unless explicitly ignored
+	if noAutoEnv, found := os.LookupEnv("PLUGIN_NO_AUTO_ENV"); found {
+		if noAutoEnv != "true" {
+			_ = godotenv.Load()
+		}
+	}
+
 	// Load env-file if it exists first
 	if filename, found := os.LookupEnv("PLUGIN_ENV_FILE"); found {
 		_ = godotenv.Load(filename)


### PR DESCRIPTION
This pull request disables dotenv autoloading if the `no_auto_env` setting is set to `"true"`.  

As an alternative, see #243.

Fixes #239 