### PR TITLE
Remove dotenv autoloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,7 @@ See [DOCS.md](./DOCS.md) for examples and full configuration options
 Configuration options are loaded from multiple sources:
 
 0. Hardcoded drone-ssh defaults.  See [main.go CLI Flags](https://github.com/appleboy/drone-ssh/blob/6d9d6acc6aef1f9166118c6ba8bd214d3a582bdb/main.go#L39) for more information.
-1. From a `.env` [dotenv](https://github.com/joho/godotenv) file at the root of the repository tested by drone.
-2. From a dotenv file at a path specified by the `PLUGIN_ENV_FILE` environment variable.
-3. From your `.drone.yml` Drone configuration.
+1. From a dotenv file at a path specified by the `PLUGIN_ENV_FILE` environment variable.
+2. From your `.drone.yml` Drone configuration.
 
 Later sources override previous sources, i.e. if `PORT` is set in an `.env` file committed in the repository or created by previous test steps, it will override the default set `main.go`.

--- a/main.go
+++ b/main.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/appleboy/easyssh-proxy"
 	"github.com/joho/godotenv"
-	_ "github.com/joho/godotenv/autoload"
 	"github.com/urfave/cli/v2"
 )
 


### PR DESCRIPTION
This removes autoloading `.env` files.  It is however backwards incompatible if anyone assumes that drone-ssh will autoload their `.env` files but can be worked around by manually setting the `env_file` drone setting.

As an alternative, see #242 

Fixes #239 