### PR TITLE
refactor: set default environment variables format in plugin

### DIFF
--- a/main.go
+++ b/main.go
@@ -199,8 +199,8 @@ func main() {
 		&cli.StringFlag{
 			Name:    "envs.format",
 			Usage:   "",
-			EnvVars: []string{"PLUGIN_ENVS_FORMAT"},
-			Value:   "export {NAME}={VALUE}",
+			EnvVars: []string{"PLUGIN_ENVS_FORMAT", "INPUT_ENVS_FORMAT"},
+			Value:   envsFormat,
 		},
 	}
 

--- a/plugin.go
+++ b/plugin.go
@@ -17,6 +17,7 @@ var (
 	errMissingHost          = errors.New("Error: missing server host")
 	errMissingPasswordOrKey = errors.New("Error: can't connect without a private SSH key or password")
 	errCommandTimeOut       = errors.New("Error: command timeout")
+	envsFormat              = "export {NAME}={VALUE}"
 )
 
 type (
@@ -177,6 +178,10 @@ func (p Plugin) Exec() error {
 
 	if len(p.Config.Key) == 0 && len(p.Config.Password) == 0 && len(p.Config.KeyPath) == 0 {
 		return errMissingPasswordOrKey
+	}
+
+	if p.Config.EnvsFormat == "" {
+		p.Config.EnvsFormat = envsFormat
 	}
 
 	wg := sync.WaitGroup{}


### PR DESCRIPTION
- Add `INPUT_ENVS_FORMAT` to the list of environment variables in `main.go`
- Define `envsFormat` variable in `plugin.go`
- Add default value for `Config.EnvsFormat` in `plugin.go` `Exec()` function

fix https://github.com/appleboy/drone-ssh/pull/235