### PR TITLE
feat: implement and test all environment variables functionality

### DIFF
--- a/main.go
+++ b/main.go
@@ -215,6 +215,11 @@ func main() {
 			EnvVars: []string{"PLUGIN_ENVS_FORMAT", "INPUT_ENVS_FORMAT"},
 			Value:   envsFormat,
 		},
+		&cli.BoolFlag{
+			Name:    "allenvs",
+			Usage:   "pass all environment variable to shell script",
+			EnvVars: []string{"PLUGIN_ALLENVS", "INPUT_ALLENVS"},
+		},
 	}
 
 	// Override a template
@@ -282,6 +287,7 @@ func run(c *cli.Context) error {
 			Sync:              c.Bool("sync"),
 			Ciphers:           c.StringSlice("ciphers"),
 			UseInsecureCipher: c.Bool("useInsecureCipher"),
+			AllEnvs:           c.Bool("allenvs"),
 			Proxy: easyssh.DefaultConfig{
 				Key:               c.String("proxy.ssh-key"),
 				KeyPath:           c.String("proxy.key-path"),

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -875,9 +875,14 @@ func TestAllEnvs(t *testing.T) {
 	var (
 		buffer   bytes.Buffer
 		expected = `
-			out: [foobar]
-			out: [foobar]
-			out: [foobar]
+======CMD======
+echo "[${INPUT_1}]"
+echo "[${GITHUB_2}]"
+echo "[${PLUGIN_3}]"
+======END======
+out: [foobar]
+out: [foobar]
+out: [foobar]
 		`
 	)
 


### PR DESCRIPTION
- Add a new flag `allenvs` to pass all environment variables to the shell script
- Implement the `AllEnvs` functionality in the `exec` function
- Add a new function `findEnvs` to find all environment variables with specified prefixes
- Add tests for the `findEnvs` function and the `AllEnvs` functionality