### PR TITLE
test: enhance testing and internal API robustness

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,9 @@ jobs:
 
   testing:
     runs-on: ubuntu-latest
-    container: golang:1.21-alpine
+    container:
+      image: golang:1.21-alpine
+      options: --sysctl net.ipv6.conf.all.disable_ipv6=0
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,11 +34,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Set up WARP
-        uses: fscarmen/warp-on-actions@v1.1
-        with:
-          stack: dual
-
       - name: setup sshd server
         run: |
           apk add git make curl perl bash build-base zlib-dev ucl-dev sudo

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,6 +34,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Set up WARP
+        uses: fscarmen/warp-on-actions@v1.1
+        with:
+          stack: dual
+
       - name: setup sshd server
         run: |
           apk add git make curl perl bash build-base zlib-dev ucl-dev sudo

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -432,7 +432,6 @@ func getHostPublicKeyFile(keypath string) (ssh.PublicKey, error) {
 	}
 
 	pubkey, _, _, _, err = ssh.ParseAuthorizedKey(buf)
-
 	if err != nil {
 		return nil, err
 	}
@@ -965,33 +964,31 @@ func TestSudoCommand(t *testing.T) {
 	assert.Equal(t, unindent(expected), unindent(buffer.String()))
 }
 
-// TODO: TestCommandWithIPv6 is not working on github actions.
-// func TestCommandWithIPv6(t *testing.T) {
-// 	var (
-// 		buffer   bytes.Buffer
-// 		expected = `
-// 			======CMD======
-// 			whoami
-// 			======END======
-// 			out: drone-scp
-// 		`
-// 	)
+func TestCommandWithIPv6(t *testing.T) {
+	var (
+		buffer   bytes.Buffer
+		expected = `
+			======CMD======
+			whoami
+			======END======
+			out: ubuntu
+		`
+	)
 
-// 	plugin := Plugin{
-// 		Config: Config{
-// 			Host:     []string{"::1"},
-// 			Username: "drone-scp",
-// 			Port:     22,
-// 			KeyPath:  "./tests/.ssh/id_rsa",
-// 			Script: []string{
-// 				"whoami",
-// 			},
-// 			Protocol:       easyssh.PROTOCOL_TCP6,
-// 			CommandTimeout: 10 * time.Second,
-// 		},
-// 		Writer: &buffer,
-// 	}
-
-// 	assert.Nil(t, plugin.Exec())
-// 	assert.Equal(t, unindent(expected), unindent(buffer.String()))
-// }
+	plugin := Plugin{
+		Config: Config{
+			Host:     []string{"2402:1f00:8000:800::2628"},
+			Username: "ubuntu",
+			Port:     22,
+			Password: "1234567890",
+			Script: []string{
+				"whoami",
+			},
+			Protocol:       easyssh.PROTOCOL_TCP6,
+			CommandTimeout: 10 * time.Second,
+		},
+		Writer: &buffer,
+	}
+	assert.Nil(t, plugin.Exec())
+	assert.Equal(t, unindent(expected), unindent(buffer.String()))
+}

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -971,16 +971,16 @@ func TestCommandWithIPv6(t *testing.T) {
 			======CMD======
 			whoami
 			======END======
-			out: ubuntu
+			out: drone-scp
 		`
 	)
 
 	plugin := Plugin{
 		Config: Config{
-			Host:     []string{"2402:1f00:8000:800::2628"},
-			Username: "ubuntu",
+			Host:     []string{"::1"},
+			Username: "drone-scp",
 			Port:     22,
-			Password: "1234567890",
+			KeyPath:  "./tests/.ssh/id_rsa",
 			Script: []string{
 				"whoami",
 			},


### PR DESCRIPTION
- Re-enable previously commented out test `TestCommandWithIPv6` in `plugin_test.go`