### PR TITLE
test: enable comprehensive debugging in plugin execution

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -125,7 +125,7 @@ func (p Plugin) exec(host string, wg *sync.WaitGroup, errChannel chan error) {
 
 	p.Config.Script = append(env, p.scriptCommands()...)
 
-	if p.Config.Debug {
+	if p.Config.Debug && len(env) > 0 {
 		p.log(host, "======ENV======")
 		p.log(host, strings.Join(env, "\n"))
 		p.log(host, "======END======")

--- a/plugin.go
+++ b/plugin.go
@@ -105,9 +105,11 @@ func (p Plugin) exec(host string, wg *sync.WaitGroup, errChannel chan error) {
 		},
 	}
 
-	p.log(host, "======CMD======")
-	p.log(host, strings.Join(p.Config.Script, "\n"))
-	p.log(host, "======END======")
+	if p.Config.Debug {
+		p.log(host, "======CMD======")
+		p.log(host, strings.Join(p.Config.Script, "\n"))
+		p.log(host, "======END======")
+	}
 
 	env := []string{}
 	if p.Config.AllEnvs {

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -392,6 +392,7 @@ func TestCommandOutput(t *testing.T) {
 			},
 			CommandTimeout: 60 * time.Second,
 			Sync:           true,
+			Debug:          true,
 		},
 		Writer: &buffer,
 	}
@@ -477,10 +478,6 @@ func TestScriptStopWithMultipleHostAndSyncMode(t *testing.T) {
 	var (
 		buffer   bytes.Buffer
 		expected = `
-			======CMD======
-			mkdir a/b/c
-			mkdir d/e/f
-			======END======
 			err: mkdir: can't create directory 'a/b/c': No such file or directory
 		`
 	)
@@ -512,10 +509,6 @@ func TestScriptStop(t *testing.T) {
 	var (
 		buffer   bytes.Buffer
 		expected = `
-			======CMD======
-			mkdir a/b/c
-			mkdir d/e/f
-			======END======
 			err: mkdir: can't create directory 'a/b/c': No such file or directory
 		`
 	)
@@ -546,10 +539,6 @@ func TestNoneScriptStop(t *testing.T) {
 	var (
 		buffer   bytes.Buffer
 		expected = `
-			======CMD======
-			mkdir a/b/c
-			mkdir d/e/f
-			======END======
 			err: mkdir: can't create directory 'a/b/c': No such file or directory
 			err: mkdir: can't create directory 'd/e/f': No such file or directory
 		`
@@ -733,10 +722,6 @@ func TestUseInsecureCipher(t *testing.T) {
 	var (
 		buffer   bytes.Buffer
 		expected = `
-			======CMD======
-			mkdir a/b/c
-			mkdir d/e/f
-			======END======
 			err: mkdir: can't create directory 'a/b/c': No such file or directory
 			err: mkdir: can't create directory 'd/e/f': No such file or directory
 		`
@@ -889,11 +874,6 @@ func TestAllEnvs(t *testing.T) {
 	var (
 		buffer   bytes.Buffer
 		expected = `
-======CMD======
-echo "[${INPUT_1}]"
-echo "[${GITHUB_2}]"
-echo "[${PLUGIN_3}]"
-======END======
 out: [foobar]
 out: [foobar]
 out: [foobar]
@@ -956,6 +936,7 @@ func TestSudoCommand(t *testing.T) {
 			},
 			CommandTimeout: 10 * time.Second,
 			RequireTty:     true,
+			Debug:          true,
 		},
 		Writer: &buffer,
 	}
@@ -968,9 +949,6 @@ func TestCommandWithIPv6(t *testing.T) {
 	var (
 		buffer   bytes.Buffer
 		expected = `
-			======CMD======
-			whoami
-			======END======
 			out: drone-scp
 		`
 	)

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -918,9 +918,6 @@ func TestSudoCommand(t *testing.T) {
 	var (
 		buffer   bytes.Buffer
 		expected = `
-			======CMD======
-			sudo su - -c "whoami"
-			======END======
 			out: root
 		`
 	)
@@ -936,7 +933,6 @@ func TestSudoCommand(t *testing.T) {
 			},
 			CommandTimeout: 10 * time.Second,
 			RequireTty:     true,
-			Debug:          true,
 		},
 		Writer: &buffer,
 	}

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -365,6 +365,9 @@ func TestCommandOutput(t *testing.T) {
 			whoami
 			uname
 			localhost: ======END======
+			localhost: ======ENV======
+			localhost:
+			localhost: ======END======
 			localhost: out: /home/drone-scp
 			localhost: out: drone-scp
 			localhost: out: Linux
@@ -372,6 +375,9 @@ func TestCommandOutput(t *testing.T) {
 			127.0.0.1: pwd
 			whoami
 			uname
+			127.0.0.1: ======END======
+			127.0.0.1: ======ENV======
+			127.0.0.1:
 			127.0.0.1: ======END======
 			127.0.0.1: out: /home/drone-scp
 			127.0.0.1: out: drone-scp
@@ -444,9 +450,6 @@ func TestFingerprint(t *testing.T) {
 	var (
 		buffer   bytes.Buffer
 		expected = `
-			======CMD======
-			whoami
-			======END======
 			out: drone-scp
 		`
 	)

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -365,9 +365,6 @@ func TestCommandOutput(t *testing.T) {
 			whoami
 			uname
 			localhost: ======END======
-			localhost: ======ENV======
-			localhost:
-			localhost: ======END======
 			localhost: out: /home/drone-scp
 			localhost: out: drone-scp
 			localhost: out: Linux
@@ -375,9 +372,6 @@ func TestCommandOutput(t *testing.T) {
 			127.0.0.1: pwd
 			whoami
 			uname
-			127.0.0.1: ======END======
-			127.0.0.1: ======ENV======
-			127.0.0.1:
 			127.0.0.1: ======END======
 			127.0.0.1: out: /home/drone-scp
 			127.0.0.1: out: drone-scp


### PR DESCRIPTION
- Add debug logging to `exec` function in `plugin.go`
- Enable debug mode in `TestCommandOutput` and `TestSudoCommand` tests
- Remove redundant command blocks from multiple tests in `plugin_test.go`